### PR TITLE
Add explicit support for generating images of drill layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ test/mismatch/
 test/outputs/
 win32/BUGS.txt
 win32/COPYING.txt
+.DS_Store

--- a/src/gerbv.c
+++ b/src/gerbv.c
@@ -616,6 +616,23 @@ gerbv_open_image(gerbv_project_t *gerbvProject, gchar const* filename, int idx, 
 } /* open_image */
 
 gerbv_image_t *
+gerbv_create_excellon_image_from_filename (gchar *filename){
+   gerbv_image_t *returnImage;
+   gerb_file_t *fd;
+
+   fd = gerb_fopen(filename);
+   if (fd == NULL) {
+           GERB_MESSAGE("Trying to open %s: %s\n", filename, strerror(errno));
+           return NULL;
+   }
+   gchar *currentLoadDirectory = g_path_get_dirname (filename);
+   returnImage = parse_drillfile(fd, (gerbv_HID_Attribute*)currentLoadDirectory, 0, 0);
+   g_free (currentLoadDirectory);
+   gerb_fclose(fd);
+   return returnImage;
+}
+
+gerbv_image_t *
 gerbv_create_rs274x_image_from_filename (gchar const* filename){
 	gerbv_image_t *returnImage;
 	gerb_file_t *fd;

--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -981,6 +981,14 @@ gerbv_export_dxf_file_from_image (const gchar *filename, /*!< the filename for t
 		gerbv_user_transformation_t *transform /*!< the transformation to apply before exporting */
 );
 
+
+//! Parse a Excellon drill file and return the parsed image
+//! \return the new gerbv_image_t, or NULL if not successful
+gerbv_image_t *
+gerbv_create_excellon_image_from_filename (gchar *filename /*!< the filename of the file to be parsed*/
+);
+
+
 //! Parse a RS274X file and return the parsed image
 //! \return the new gerbv_image_t, or NULL if not successful
 gerbv_image_t *


### PR DESCRIPTION
For PCBTestSuite usage. Right now there is no way to generate PNGs of drill files by themselves. 