### PR TITLE
fix compilation failure

### DIFF
--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -40,14 +40,13 @@ typedef enum {
 	CALLBACKS_SAVE_FILE_DRILLM,
 	CALLBACKS_SAVE_LAYER_AS,
 	CALLBACKS_SAVE_FILE_IDRILL
-	
-} CALLBACKS_SAVE_FILE_TYPE;
+};
 
 typedef enum {
 	LAYER_SELECTED =	-1,
 	LAYER_ALL_ON =		-2,
 	LAYER_ALL_OFF =		-3,
-} toggle_layer;
+};
 
 void
 callbacks_new_project_activate                (GtkMenuItem     *menuitem,


### PR DESCRIPTION
Fixes the compile failure. Apparently this worked with older compilers but this was not intentional, it should have thrown an error. Newer versions won't link gerbv correctly without this change. 

```
ld.lld: error: duplicate symbol: CALLBACKS_SAVE_FILE_TYPE
>>> defined at callbacks.c
>>>            callbacks.o:(CALLBACKS_SAVE_FILE_TYPE)
>>> defined at interface.c
>>>            interface.o:(.bss+0xC)

ld.lld: error: duplicate symbol: toggle_layer
>>> defined at callbacks.c
>>>            callbacks.o:(toggle_layer)
>>> defined at interface.c
>>>            interface.o:(.bss+0x10)

ld.lld: error: duplicate symbol: CALLBACKS_SAVE_FILE_TYPE
>>> defined at callbacks.c
>>>            callbacks.o:(CALLBACKS_SAVE_FILE_TYPE)
>>> defined at main.c
>>>            main.o:(.bss+0x448)

ld.lld: error: duplicate symbol: toggle_layer
>>> defined at callbacks.c
>>>            callbacks.o:(toggle_layer)
>>> defined at main.c
>>>            main.o:(.bss+0x44C)

ld.lld: error: duplicate symbol: CALLBACKS_SAVE_FILE_TYPE
>>> defined at callbacks.c
>>>            callbacks.o:(CALLBACKS_SAVE_FILE_TYPE)
>>> defined at render.c
>>>            render.o:(.bss+0x30)

ld.lld: error: duplicate symbol: toggle_layer
>>> defined at callbacks.c
>>>            callbacks.o:(toggle_layer)
>>> defined at render.c
>>>            render.o:(.bss+0x34)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[3]: *** [Makefile:683: gerbv] Error 1
make[3]: Leaving directory '/tmp/gerbv/src'
make[2]: *** [Makefile:558: all] Error 2
make[2]: Leaving directory '/tmp/gerbv/src'
make[1]: *** [Makefile:514: all-recursive] Error 1
make[1]: Leaving directory '/tmp/gerbv'
make: *** [Makefile:444: all] Error 2
```