### PR TITLE
toggle_layer and CALLBACKS_SAVE_FILE_TYPE should be types not variables

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -11,8 +11,8 @@ on:
     types: [created]
 
 jobs:
-    build-image:
-        name: Build image
+    build-image-20-04:
+        name: Build image 20.04
         if: ${{ !github.event.pull_request.draft }}
         runs-on: ubuntu-20.04
         steps:
@@ -37,4 +37,30 @@ jobs:
             with:
                 files: ../gerbv.tar.gz
 
-                
+    build-image-22-04:
+        name: Build image 22.04
+        if: ${{ !github.event.pull_request.draft }}
+        runs-on: ubuntu-22.04
+        steps:
+          - name: Checkout the Repo
+            uses: actions/checkout@v2
+          - name: install deps
+            run: |
+                sudo apt update
+                sudo apt -y install autoconf autopoint build-essential curl git libcairo2-dev libgtk2.0-dev make m4 pandoc pkg-config
+          - name: build package
+            run: |
+                ./autogen.sh
+                ./configure --disable-update-desktop-database
+                make
+                mkdir ../install
+                make install DESTDIR=$(pwd)/../install/
+                cd ../install
+                tar zcvf ../gerbv-22.04.tar.gz usr/local
+          - name: upload the artifacts
+            if: github.event_name == 'release' && github.event.action == 'created'
+            uses: softprops/action-gh-release@v1
+            with:
+                files: ../gerbv-22.04.tar.gz
+
+

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -26,7 +26,7 @@
     \ingroup gerbv
 */
 
-enum {
+typedef enum {
 	CALLBACKS_SAVE_PROJECT_AS,
 	CALLBACKS_SAVE_FILE_PS,
 	CALLBACKS_SAVE_FILE_PDF,
@@ -43,7 +43,7 @@ enum {
 	
 } CALLBACKS_SAVE_FILE_TYPE;
 
-enum {
+typedef enum {
 	LAYER_SELECTED =	-1,
 	LAYER_ALL_ON =		-2,
 	LAYER_ALL_OFF =		-3,


### PR DESCRIPTION
Newer versions of gcc do not combine common objects without `-fcommon`:
```
/usr/bin/ld: interface.o:/home/ddrown/git/gerbv/src/callbacks.h:50: multiple definition of `toggle_layer'; callbacks.o:/home/ddrown/git/gerbv/src/callbacks.h:50: first defined here
/usr/bin/ld: interface.o:/home/ddrown/git/gerbv/src/callbacks.h:44: multiple definition of `CALLBACKS_SAVE_FILE_TYPE'; callbacks.o:/home/ddrown/git/gerbv/src/callbacks.h:44: first defined here
/usr/bin/ld: main.o:/home/ddrown/git/gerbv/src/callbacks.h:50: multiple definition of `toggle_layer'; callbacks.o:/home/ddrown/git/gerbv/src/callbacks.h:50: first defined here
/usr/bin/ld: main.o:/home/ddrown/git/gerbv/src/callbacks.h:44: multiple definition of `CALLBACKS_SAVE_FILE_TYPE'; callbacks.o:/home/ddrown/git/gerbv/src/callbacks.h:44: first defined here
/usr/bin/ld: render.o:/home/ddrown/git/gerbv/src/callbacks.h:50: multiple definition of `toggle_layer'; callbacks.o:/home/ddrown/git/gerbv/src/callbacks.h:50: first defined here
/usr/bin/ld: render.o:/home/ddrown/git/gerbv/src/callbacks.h:44: multiple definition of `CALLBACKS_SAVE_FILE_TYPE'; callbacks.o:/home/ddrown/git/gerbv/src/callbacks.h:44: first defined here
```