### PR TITLE
MFP1-2090: Update Ubuntu version in CI

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -14,7 +14,7 @@ jobs:
     build-image:
         name: Build image
         if: ${{ !github.event.pull_request.draft }}
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
           - name: Checkout the Repo
             uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         coverage: ["-coverage", ""] # Coverage build and a regular one


### PR DESCRIPTION
https://macrofab.atlassian.net/browse/MFP1-2090 

This PR updates the Ubuntu version in CI workflows from 'ubuntu-20.04' to 'ubuntu-22.04' as part of the MFP1-2090 initiative. See https://github.com/actions/runner-images/issues/11101 for more information.