### PR TITLE
2.7.x: Update build target

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -11,18 +11,18 @@ on:
     types: [created]
 
 jobs:
-  build-image-20-04:
-    name: Build image 20.04
-    uses: ./.github/workflows/build-binary-on-ubuntu.yaml
-    with:
-      ubuntu_version: 20.04
-      filename: gerbv.tar.gz
-      upload: ${{ github.event_name == 'release' && github.event.action == 'created' }}
-
   build-image-22-04:
     name: Build image 22.04
     uses: ./.github/workflows/build-binary-on-ubuntu.yaml
     with:
       ubuntu_version: 22.04
       filename: gerbv-22.04.tar.gz
+      upload: ${{ github.event_name == 'release' && github.event.action == 'created' }}
+
+  build-image-24-04:
+    name: Build image 24.04
+    uses: ./.github/workflows/build-binary-on-ubuntu.yaml
+    with:
+      ubuntu_version: 24.04
+      filename: gerbv-24.04.tar.gz
       upload: ${{ github.event_name == 'release' && github.event.action == 'created' }}


### PR DESCRIPTION
* Remove ubuntu 20.04 as a CI build target like https://github.com/MacroFab/gerbv/pull/12. See actions/runner-images#11101 for more information.
* Add ubuntu 24.04 as a target, in anticipation of us migrating to it soon.